### PR TITLE
Change downloads bar color to black on Chrome 73

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,11 +3,12 @@
 
 	"name": "Material Deep Black Theme",
 	"description": "A theme that adds a black colour scheme to Chrome.",
-	"version": "4.0.1",
+	"version": "4.0.2",
 
 	"theme": {
 		"images": {
-			"theme_ntp_background": "images/black.png"
+			"theme_ntp_background": "images/black.png",
+			"theme_toolbar": "images/black.png"
 		},
 		"colors": {
 			"bookmark_text": [255, 255, 255],


### PR DESCRIPTION
The downloads bar at the bottom of the window with this theme became white with the new Chrome update. White text on white background is obviously impossible to read. I found a way to fix it — by adding the "theme_toolbar" image.